### PR TITLE
Remove readonly in attributes to be php 7.4 compatible. Fixes #6

### DIFF
--- a/public/class-schema-scalpel-public.php
+++ b/public/class-schema-scalpel-public.php
@@ -25,14 +25,14 @@ class Schema_Scalpel_Public {
 	 *
 	 * @var string
 	 */
-	private readonly string $schema_scalpel;
+	private string $schema_scalpel;
 
 	/**
 	 * Plugin version.
 	 *
 	 * @var string
 	 */
-	private readonly string $version;
+	private string $version;
 
 	/**
 	 * Class constructor.


### PR DESCRIPTION
Remove keyword readonly in class attributes to be 7.4 compatible.

This fixes #6